### PR TITLE
ara: use correct variable for enabling persistent volumes

### DIFF
--- a/charts/ara/Chart.yaml
+++ b/charts/ara/Chart.yaml
@@ -14,4 +14,4 @@ name: ara
 sources:
 - https://github.com/ansible-community/ara
 - https://github.com/lib42/charts
-version: 0.1.3
+version: 0.1.4

--- a/charts/ara/templates/pvc.yaml
+++ b/charts/ara/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.persistence.enabled }}
+{{- if $.Values.persistentVolumes.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
Signed-off-by: Ryan Taylor <1686627+rptaylor@users.noreply.github.com>

A default out-of-the-box installation of the ara chart fails because `$.Values.persistence.enabled` is referenced but not defined anywhere. 
```
"Failure when executing Helm command. Exited 1.\nstdout: Release \"ara\" does not exist. Installing it now.\n\nstderr: Error: template: ara/templates/pvc.yaml:1:8: executing \"ara/templates/pvc.yaml\" at <$.Values.persistence.enabled>: nil pointer evaluating interface {}.enabled\n", "stderr": "Error: template: ara/templates/pvc.yaml:1:8: executing \"ara/templates/pvc.yaml\" at <$.Values.persistence.enabled>: nil pointer evaluating interface {}.enabled\n", "stderr_lines": ["Error: template: ara/templates/pvc.yaml:1:8: executing \"ara/templates/pvc.yaml\" at <$.Values.persistence.enabled>: nil pointer evaluating interface {}.enabled"]
```

It looks like the variable `$.Values.persistentVolumes.enabled` should be used for this, and it already exists in the values.yml file.