### PR TITLE
fix: host header for probes

### DIFF
--- a/charts/ara/Chart.yaml
+++ b/charts/ara/Chart.yaml
@@ -14,4 +14,4 @@ name: ara
 sources:
 - https://github.com/ansible-community/ara
 - https://github.com/lib42/charts
-version: 0.2.0
+version: 0.2.1

--- a/charts/ara/templates/deployment.yaml
+++ b/charts/ara/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             path: {{ $.Values.probePath }}
             httpHeaders:
               - name: Host
-                value: {{ $.Values.ingress.host }}
+                value: {{ first $.Values.ingress.hosts }}
           initialDelaySeconds: 30
           failureThreshold: 3
           timeoutSeconds: 1
@@ -62,7 +62,7 @@ spec:
             path: {{ $.Values.probePath }}
             httpHeaders:
               - name: Host
-                value: {{ $.Values.ingress.host }}
+                value: {{ first $.Values.ingress.hosts }}
           initialDelaySeconds: 30
           failureThreshold: 3
           timeoutSeconds: 1
@@ -73,7 +73,7 @@ spec:
             path: {{ $.Values.probePath }}
             httpHeaders:
               - name: Host
-                value: {{ $.Values.ingress.host }}
+                value: {{ first $.Values.ingress.hosts }}
           initialDelaySeconds: 30
           failureThreshold: 30
           timeoutSeconds: 1


### PR DESCRIPTION
Hi,

While doing #16 I didn't realize HTTP probes were using `ingress.host` as HTTP header.
This is the fix for this.