### PR TITLE
fix(ara): Set default probe path to /healthcheck/

### DIFF
--- a/charts/ara/Chart.yaml
+++ b/charts/ara/Chart.yaml
@@ -14,4 +14,4 @@ name: ara
 sources:
 - https://github.com/ansible-community/ara
 - https://github.com/lib42/charts
-version: 0.3.0
+version: 0.3.1

--- a/charts/ara/values.yaml
+++ b/charts/ara/values.yaml
@@ -50,7 +50,7 @@ ingress:
 resources: {}
 
 # Path for liveness and readiness probes (has to be changed if ARA_BASE_PATH is non-default).
-probePath: "/api/v1/"
+probePath: "/healthcheck/"
 
 # Persistent volume for SQLite DB:
 persistentVolumes:


### PR DESCRIPTION
ARA has built-in healthcheck under `/healthcheck/` path.

It is better suited for probes, especially in the case of also setting `ARA_READ_LOGIN_REQUIRED` to `True`. Previously used `/api/v1/` will return 401 in that case, failing the check, even though app is running.