### PR TITLE
fix: rename podSecurityContext to containerSecurityContext

### DIFF
--- a/charts/ara/Chart.yaml
+++ b/charts/ara/Chart.yaml
@@ -14,4 +14,4 @@ name: ara
 sources:
 - https://github.com/ansible-community/ara
 - https://github.com/lib42/charts
-version: 0.4.0
+version: 0.4.1

--- a/charts/ara/templates/deployment.yaml
+++ b/charts/ara/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           initialDelaySeconds: 30
           failureThreshold: 30
           timeoutSeconds: 1
-        {{- with .Values.podSecurityContext }}
+        {{- with .Values.containerSecurityContext }}
         securityContext: {{ toYaml . | nindent 10 }}
         {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/ara/values.yaml
+++ b/charts/ara/values.yaml
@@ -69,4 +69,4 @@ securityContext:
   runAsGroup: 2000
   fsGroup: 2000
 
-podSecurityContext: {}
+containerSecurityContext: {}


### PR DESCRIPTION
Hi, I realized I made a typo during the previous change. This should be `containerSecurityContext`.