### PR TITLE
ARA: Fix resource definition

### DIFF
--- a/charts/ara/Chart.yaml
+++ b/charts/ara/Chart.yaml
@@ -14,4 +14,4 @@ name: ara
 sources:
 - https://github.com/ansible-community/ara
 - https://github.com/lib42/charts
-version: 0.4.1
+version: 0.4.2

--- a/charts/ara/templates/deployment.yaml
+++ b/charts/ara/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- end }}
         {{- if $.Values.resources }}
         resources:
-          {{-  toYaml $.Values.resources | nindent 8 }}
+          {{-  toYaml $.Values.resources | nindent 10 }}
         {{- end }}
         {{- if $.Values.envFromSecret }}
         envFrom:


### PR DESCRIPTION
It is not currently possible to set resources in the ARA chart because of the wrong indentation level. I tested this with `helm template ara ./ara -f values.yml`  and this values file:
```
resources:
  requests:
    cpu: 1
    memory: 1Gi
  limits:
    cpu: 3
    memory: 1Gi
```

Before:
```
      containers:
      - image: docker.io/recordsansible/ara-api:latest
        imagePullPolicy: IfNotPresent
        name: ara
        resources:
        limits:
          cpu: 3
          memory: 1Gi
        requests:
          cpu: 1
          memory: 1Gi
```
After:
```
      containers:
      - image: docker.io/recordsansible/ara-api:latest
        imagePullPolicy: IfNotPresent
        name: ara
        resources:
          limits:
            cpu: 3
            memory: 1Gi
          requests:
            cpu: 1
            memory: 1Gi
```
