### PR TITLE
ARA: make probes configurable

### DIFF
--- a/charts/ara/Chart.yaml
+++ b/charts/ara/Chart.yaml
@@ -14,4 +14,4 @@ name: ara
 sources:
 - https://github.com/ansible-community/ara
 - https://github.com/lib42/charts
-version: 0.4.2
+version: 0.4.3

--- a/charts/ara/templates/deployment.yaml
+++ b/charts/ara/templates/deployment.yaml
@@ -44,37 +44,11 @@ spec:
         ports:
           - containerPort: 8000
         livenessProbe:
-          httpGet:
-            port: 8000
-            path: {{ $.Values.probePath }}
-            httpHeaders:
-              - name: Host
-                value: {{ first $.Values.ingress.hosts }}
-          initialDelaySeconds: 30
-          failureThreshold: 3
-          timeoutSeconds: 1
-          periodSeconds: 10
+          {{- tpl (toYaml .Values.livenessProbe) . | nindent 10 }}
         readinessProbe:
-          httpGet:
-            port: 8000
-            path: {{ $.Values.probePath }}
-            httpHeaders:
-              - name: Host
-                value: {{ first $.Values.ingress.hosts }}
-          initialDelaySeconds: 30
-          failureThreshold: 3
-          timeoutSeconds: 1
-          periodSeconds: 10
+          {{- tpl (toYaml .Values.readinessProbe) . | nindent 10 }}
         startupProbe:
-          httpGet:
-            port: 8000
-            path: {{ $.Values.probePath }}
-            httpHeaders:
-              - name: Host
-                value: {{ first $.Values.ingress.hosts }}
-          initialDelaySeconds: 30
-          failureThreshold: 30
-          timeoutSeconds: 1
+          {{- tpl (toYaml .Values.startupProbe) . | nindent 10 }}
         {{- with .Values.containerSecurityContext }}
         securityContext: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/ara/values.yaml
+++ b/charts/ara/values.yaml
@@ -52,6 +52,40 @@ resources: {}
 # Path for liveness and readiness probes (has to be changed if ARA_BASE_PATH is non-default).
 probePath: "/healthcheck/"
 
+# Configuration of liveness, readiness, and startup probes
+livenessProbe:
+  httpGet:
+    port: 8000
+    path: "{{ .Values.probePath }}"
+    httpHeaders:
+      - name: Host
+        value: "{{ first .Values.ingress.hosts }}"
+  initialDelaySeconds: 30
+  failureThreshold: 3
+  timeoutSeconds: 1
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    port: 8000
+    path: "{{ .Values.probePath }}"
+    httpHeaders:
+      - name: Host
+        value: "{{ first .Values.ingress.hosts }}"
+  initialDelaySeconds: 30
+  failureThreshold: 3
+  timeoutSeconds: 1
+  periodSeconds: 10
+startupProbe:
+  httpGet:
+    port: 8000
+    path: "{{ .Values.probePath }}"
+    httpHeaders:
+      - name: Host
+        value: "{{ first .Values.ingress.hosts }}"
+  initialDelaySeconds: 30
+  failureThreshold: 30
+  timeoutSeconds: 1
+
 # Persistent volume for SQLite DB:
 persistentVolumes:
   enabled: false


### PR DESCRIPTION
This MR allows any/all possible properties of the ARA startup, readiness, and liveness probes to be configurable Helm values, without introducing any complex templating to handle those values (inspired by [this](https://austindewey.com/2021/02/22/using-the-helm-tpl-function-to-refer-values-in-values-files/)).
This also allows users to remove probe parameters if they want by setting a value to `null`.
The tpl function is used for values that refer to values (required because of the probePath and ingress hosts fields).

The default values remain the same so there is no change in behaviour in the default case.
