### PR TITLE
ara: add pod preferred anti-affinity

### DIFF
--- a/charts/ara/Chart.yaml
+++ b/charts/ara/Chart.yaml
@@ -14,4 +14,4 @@ name: ara
 sources:
 - https://github.com/ansible-community/ara
 - https://github.com/lib42/charts
-version: 0.4.4
+version: 0.4.6

--- a/charts/ara/templates/deployment.yaml
+++ b/charts/ara/templates/deployment.yaml
@@ -15,6 +15,20 @@ spec:
       labels:
         app: ara
     spec:
+      {{- if gt .Values.replicas 1 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - ara
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+      {{- end }}
       {{- with .Values.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
For a HA deployment of > 1 ara pods, use a pod anti-affinity so they prefer to avoid running on the same node.
This improves reliability in case a node fails. 